### PR TITLE
Fixing nagios library static path issue

### DIFF
--- a/check_nginx_status.pl
+++ b/check_nginx_status.pl
@@ -12,10 +12,11 @@ use Getopt::Long;
 use LWP::UserAgent;
 use Time::HiRes qw(gettimeofday tv_interval);
 use Digest::MD5 qw(md5 md5_hex);
+use FindBin;
 
 
 # Nagios specific
-use lib "/usr/local/nagios/libexec";
+use lib $FindBin::Bin;
 use utils qw($TIMEOUT);
 
 # Globals


### PR DESCRIPTION
This should solve the problem where the nagios library path needs to be set manually. 

Before:

```
# /pub/icinga/libexec/check_nginx_status.pl -H xxx.xxx.xxx.xxx
Can't locate utils.pm in @INC (@INC contains: /usr/local/nagios/libexec /etc/perl /usr/local/lib/perl/5.14.2 /usr/local/share/perl/5.14.2 /usr/lib/perl5 /usr/share/perl5 /usr/lib/perl/5.14 /usr/share/perl/5.14 /usr/local/lib/site_perl .) at /pub/icinga/libexec/check_nginx_status.pl line 19.
```

BEGIN failed--compilation aborted at /pub/icinga/libexec/check_nginx_status.pl line 19.

After patch:

```
# /pub/icinga/libexec/check_nginx_status.pl -H xxx.xxx.xxx.xxx
NGINX OK -  0.034 sec. response time, Active: 5 (Writing: 1 Reading: 0 Waiting: 4) ReqPerSec: 0.203 ConnPerSec: 0.124 ReqPerConn: 1.479|Writing=1;Reading=0;Waiting=4;Active=5;ReqPerSec=0.202614;ConnPerSec=0.124183;ReqPerConn=1.478712
```
