### PR TITLE
Added some random perl from the internet

### DIFF
--- a/check_nginx_status.pl
+++ b/check_nginx_status.pl
@@ -16,8 +16,10 @@ use FindBin;
 
 
 # Nagios specific
+require 5.6.0;
+use lib qw( /usr/lib/nagios/plugins );
+use utils qw(%ERRORS $TIMEOUT &print_revision &support &usage);
 use lib $FindBin::Bin;
-use utils qw($TIMEOUT);
 
 # Globals
 my $Version='0.9';


### PR DESCRIPTION
We recently upgraded to a new version of nagios3, and started getting errors saying "(Service Check did not exit properly)" from this plugin.

I found this blog [post](http://adminmirror.blogspot.co.uk/2013/04/nagios-perl-plugin-service-check-did.html), and making those changes seemed to fix it. No idea what it does though :S
