### PR TITLE
Reduce shebang arguments, move -w to use warnings

### DIFF
--- a/check_nginx_status.pl
+++ b/check_nginx_status.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # check_nginx_status.pl
 # Author  : regis.leroy at makina-corpus.com
 # Licence : GPL - http://www.fsf.org/licenses/gpl.txt
@@ -6,6 +6,7 @@
 # help : ./check_nginx_status.pl -h
 #
 # issues & updates: http://github.com/regilero/check_nginx_status
+use warnings;
 use strict;
 use Getopt::Long;
 use LWP::UserAgent;


### PR DESCRIPTION
Shebang should only have command argument. Either use 'perl -w' or 'env perl', see discussion in #16. Maintainer @regilero had preference for 'env perl', so hereby the requested changes. 

Fixes issues
- #16: Shebang has too many arguments
- #17: #!/usr/bin/env perl -w in Ubuntu 16.04
