### PR TITLE
Fix error with verify_hostname on newer Perl versions

### DIFF
--- a/check_nginx_status.pl
+++ b/check_nginx_status.pl
@@ -215,7 +215,9 @@ my $ua = LWP::UserAgent->new(
 );
 
 if ( $o_disable_sslverifyhostname ) {
-  $ua->ssl_opts( 'verify_hostname' => 0 );
+  $ua->ssl_opts( 'verify_hostname' => 0,
+  SSL_verify_mode => '0',
+  );
 }
 
 # we need to enforce the HTTP request is made on the Nagios Host IP and


### PR DESCRIPTION
This patch fixes the problem:

```bash
NGINX CRITICAL - 500 Can't connect to foo.example.com:443 (certificate verify failed)
```
on newer Perl /  liblwp-protocol-https-perl versions. On Debian Stretch
